### PR TITLE
Increase MaxProximityRange to 192

### DIFF
--- a/src/TerraVoice/Systems/VoiceOutputSystem.cs
+++ b/src/TerraVoice/Systems/VoiceOutputSystem.cs
@@ -10,7 +10,7 @@ namespace TerraVoice.Systems;
 [Autoload(Side = ModSide.Client)]
 internal sealed class VoiceOutputSystem : ModSystem
 {
-    public const int MaxProximityRange = 96;
+    public const int MaxProximityRange = 192;
 
     private static PlayerSpeaker[] playerSpeakers;
 


### PR DESCRIPTION
I think 96 tiles is a little too short. Many other sounds propagate much further than 96 tiles, and it doesn't match up well. 192 is a much better value as sound falloff in vanilla will match much better with 192.